### PR TITLE
Improve speed and consistency

### DIFF
--- a/personas/isochrone.py
+++ b/personas/isochrone.py
@@ -1,6 +1,8 @@
 from personas import common
 
-from locust import HttpLocust, TaskSet, task
+from locust import TaskSet, task
+from locust.contrib.fasthttp import FastHttpLocust
+from locust.wait_time import constant_pacing
 
 
 class PersonaTaskSet(TaskSet):
@@ -16,6 +18,9 @@ class PersonaTaskSet(TaskSet):
         self.client.get(path, name="Isochrone")
 
 
-class PersonaIsochrone(HttpLocust):
+class PersonaIsochrone(FastHttpLocust):
     task_set = PersonaTaskSet
     weight = 1
+    network_timeout = 3.0
+    connection_timeout = 3.0
+    wait_time = constant_pacing(1.0)

--- a/personas/matrix.py
+++ b/personas/matrix.py
@@ -1,6 +1,8 @@
 from personas import common
 
-from locust import HttpLocust, TaskSet, task
+from locust import TaskSet, task
+from locust.contrib.fasthttp import FastHttpLocust
+from locust.wait_time import constant_pacing
 
 
 class PersonaTaskSet(TaskSet):
@@ -18,6 +20,9 @@ class PersonaTaskSet(TaskSet):
         self.client.get(path, name="Matrix", verify=False)
 
 
-class PersonaMatrix(HttpLocust):
+class PersonaMatrix(FastHttpLocust):
     task_set = PersonaTaskSet
     weight = 1
+    network_timeout = 3.0
+    connection_timeout = 3.0
+    wait_time = constant_pacing(1.0)

--- a/personas/route.py
+++ b/personas/route.py
@@ -1,6 +1,8 @@
 from personas import common
 
-from locust import HttpLocust, TaskSet, task
+from locust import TaskSet, task
+from locust.contrib.fasthttp import FastHttpLocust
+from locust.wait_time import constant_pacing
 
 
 class PersonaTaskSet(TaskSet):
@@ -18,6 +20,9 @@ class PersonaTaskSet(TaskSet):
         self.client.get(path, name="Route")
 
 
-class PersonaRoute(HttpLocust):
+class PersonaRoute(FastHttpLocust):
     task_set = PersonaTaskSet
     weight = 1
+    network_timeout = 3.0
+    connection_timeout = 3.0
+    wait_time = constant_pacing(1.0)

--- a/personas/route_invalid.py
+++ b/personas/route_invalid.py
@@ -1,5 +1,7 @@
 import random
-from locust import HttpLocust, TaskSet, task
+from locust import TaskSet, task
+from locust.contrib.fasthttp import FastHttpLocust
+from locust.wait_time import constant_pacing
 
 from personas import common
 
@@ -17,8 +19,11 @@ class PersonaTaskSet(TaskSet):
         self.client.get(path, name="Route erratic")
 
 
-class PersonaRouteInvalid(HttpLocust):
+class PersonaRouteInvalid(FastHttpLocust):
     task_set = PersonaTaskSet
     weight = 1
+    network_timeout = 3.0
+    connection_timeout = 3.0
+    wait_time = constant_pacing(1.0)
     # min_wait = 500
     # max_wait = 700

--- a/personas/vrp.py
+++ b/personas/vrp.py
@@ -3,7 +3,9 @@ import json
 import random
 import os
 import time
-from locust import events, HttpLocust, TaskSet, task
+from locust import events, TaskSet, task
+from locust.contrib.fasthttp import FastHttpLocust
+from locust.wait_time import constant_pacing
 
 from personas import common
 
@@ -62,9 +64,12 @@ class PersonaTaskSet(TaskSet):
                 time.sleep(0.33) # maximum 3 GET requests per second
 
 
-class PersonaVRP(HttpLocust):
+class PersonaVRP(FastHttpLocust):
     task_set = PersonaTaskSet
     weight = 10
+    network_timeout = 3.0
+    connection_timeout = 3.0
+    wait_time = constant_pacing(1.0)
 
 
 def get_random_vehicles_and_types(max_profiles):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
-invokust==0.52
-locustio==0.11.0
-requests==2.21.0
+invokust==0.61
+locustio==0.14.5
+requests==2.23.0


### PR DESCRIPTION
This PR does the following:

* Upgrades locust to the latest 0.14.5.
* Uses the [faster HTTP client](https://docs.locust.io/en/stable/increase-performance.html). Until now, locust used the python requests library, but this new client uses geventhttpclient, which is much faster.
* Uses the new [`wait_time`](https://docs.locust.io/en/stable/writing-a-locustfile.html#the-wait-time-attribute) attribute with the new function for constant pacing. Until now, we could only configure how much time each locust user would wait between requests. For example, if the request took 100ms and the wait time was the default 1s, the next request would happen in 1.1. This new constant pacing allows us to configure the exact requests per second. You can see that it works great [here](https://gist.github.com/rokcarl/4ebf896cb922d79f8add20771d7dfcd6), where a 60s test of 10 users did 599 requests in total on a server that simulated long-ish wait times (under 1 second). What we had before produced 419 requests on the same server.
* Sets the timeout for connections and requests to 3s. Unfortunately in my testing, this did not work as intended, so I [filed a bug](https://github.com/locustio/locust/issues/1307) with locust. I'll report back.

/cc @karussell 