### PR TITLE
Get locust to latest to respect connection timeouts

### DIFF
--- a/personas/isochrone.py
+++ b/personas/isochrone.py
@@ -19,7 +19,7 @@ class PersonaTaskSet(TaskSet):
 
 
 class PersonaIsochrone(FastHttpLocust):
-    task_set = PersonaTaskSet
+    tasks = [PersonaTaskSet]
     weight = 1
     network_timeout = 3.0
     connection_timeout = 3.0

--- a/personas/matrix.py
+++ b/personas/matrix.py
@@ -21,7 +21,7 @@ class PersonaTaskSet(TaskSet):
 
 
 class PersonaMatrix(FastHttpLocust):
-    task_set = PersonaTaskSet
+    tasks = [PersonaTaskSet]
     weight = 1
     network_timeout = 3.0
     connection_timeout = 3.0

--- a/personas/route.py
+++ b/personas/route.py
@@ -21,7 +21,7 @@ class PersonaTaskSet(TaskSet):
 
 
 class PersonaRoute(FastHttpLocust):
-    task_set = PersonaTaskSet
+    tasks = [PersonaTaskSet]
     weight = 1
     network_timeout = 3.0
     connection_timeout = 3.0

--- a/personas/route_invalid.py
+++ b/personas/route_invalid.py
@@ -20,7 +20,7 @@ class PersonaTaskSet(TaskSet):
 
 
 class PersonaRouteInvalid(FastHttpLocust):
-    task_set = PersonaTaskSet
+    tasks = [PersonaTaskSet]
     weight = 1
     network_timeout = 3.0
     connection_timeout = 3.0

--- a/personas/vrp.py
+++ b/personas/vrp.py
@@ -50,7 +50,7 @@ class PersonaTaskSet(TaskSet):
             with self.client.get(url, catch_response=True, name="VRP complex Solution", timeout=60) as response:
                 try:
                     response_data = response.json()
-                except json.decoder.JSONDecodeError as e:
+                except (json.decoder.JSONDecodeError, TypeError) as e:
                     response.failure("VRP solution failed, json decode error: {}\nCode: {}, Response text: {}".format(e, response.status_code, response.text))
                     return
                 if response.status_code == 400:
@@ -65,7 +65,7 @@ class PersonaTaskSet(TaskSet):
 
 
 class PersonaVRP(FastHttpLocust):
-    task_set = PersonaTaskSet
+    tasks = [PersonaTaskSet]
     weight = 10
     network_timeout = 3.0
     connection_timeout = 3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 docopt==0.6.2
 invokust==0.61
-locustio==0.14.5
+https://github.com/locustio/locust/archive/0b72b9bd0b3a34fad2ebc9fabfb574401e722942.zip
 requests==2.23.0

--- a/run
+++ b/run
@@ -98,7 +98,7 @@ def run_locust(settings):
 
 def run_locust_from_shell(settings):
     cmd = (
-        f"locust --no-web --host {settings['base_url']} "
+        f"locust --headless --host {settings['base_url']} "
         f"-c {settings['users']} -r {settings['users']}"
     )
     if not settings["slave"]:


### PR DESCRIPTION
Due to a [bug](https://github.com/locustio/locust/issues/1307) in Locust, I was unable to make Locust respect the timeouts, which meant that even if our service under stress took more than 3 seconds, which we'd consider downtime, the load test would take 60 seconds to timeout, meaning that we would miss the downtime if it got resolved quickly.

This PR brings the codebase to the bleeding edge, which I try to avoid, but in this instance, it's needed for proper testing. I will bring it to stable, once the locust codebase moves on.

I had to make three additional changes as per their [changelog](https://github.com/locustio/locust/blob/165a27e5504b1552ba1c55bf41fcc98c37ec2848/docs/changelog.rst) and runtime.

/cc @karussell 