### PR TITLE
Fix debugging

### DIFF
--- a/personas/common.py
+++ b/personas/common.py
@@ -56,4 +56,4 @@ def setup_locust_debugging():
     if "DEBUG" in os.environ and os.environ["DEBUG"] == "yes":
         def report_error(request_type, name, response_time, exception, **kwargs):
             print(f"Request {name} ({request_type}) failed: {exception}", flush=True)
-        events.request_failure += report_error
+        events.request_failure.add_listener(report_error)

--- a/run
+++ b/run
@@ -112,6 +112,11 @@ def run_locust_from_shell(settings):
 
 
 def run_locust_from_python(settings):
+    msg = ("I'm sorry, running the load test with some features that demand the programmatic "
+           "features of Locust is not supported yet because we're using latest Locust features, "
+           "that invokust doesn't support yet.")
+    print(msg)
+    sys.exit(1)
     locust_settings = invokust.create_settings(
         classes=[getattr(main, settings["persona_arg"])],
         host=settings["base_url"],


### PR DESCRIPTION
"Fixes" #4.

This PR fixes the `--debug` not working. But the `--custom-output` is currently not supported anymore because the [invokust](https://github.com/FutureSharks/invokust) library that we use to run locust programmatically is not up-to-date (in-sync) with locust.

So what I did was to exit the program when using `--custom-output` and notify the user that this is not supported. I think it's sufficient for now and when invokust catches up, we can restore the functionality.
Alternatively, I can code running of locust from Python completely in this repo, but it's probably not worth it.