### PR TITLE
Set version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ If, on the other hand, you're familiar with Python and its packaging system, you
 your environment as you see fit (e.g. using virtual environment). The only thing that is required
 is to install the packages in `requirements.txt`, usually done with `pip install -r requirements.txt`.
 
+### Get current version
+
+To print the current version of the app, run:
+
+    ./run --version
+
 ### Get help
 
 Run the following to see the help page on how to run this tool.

--- a/personas/isochrone.py
+++ b/personas/isochrone.py
@@ -1,8 +1,8 @@
 from personas import common
 
+import locust
 from locust import TaskSet, task
 from locust.contrib.fasthttp import FastHttpUser
-from locust.wait_time import constant_pacing
 
 
 class PersonaTaskSet(TaskSet):
@@ -23,4 +23,4 @@ class PersonaIsochrone(FastHttpUser):
     weight = 1
     network_timeout = 3.0
     connection_timeout = 3.0
-    wait_time = constant_pacing(1.0)
+    wait_time = locust.wait_time.constant_pacing(1.0)

--- a/personas/matrix.py
+++ b/personas/matrix.py
@@ -1,8 +1,8 @@
 from personas import common
 
+import locust
 from locust import TaskSet, task
 from locust.contrib.fasthttp import FastHttpUser
-from locust.wait_time import constant_pacing
 
 
 class PersonaTaskSet(TaskSet):
@@ -25,4 +25,4 @@ class PersonaMatrix(FastHttpUser):
     weight = 1
     network_timeout = 3.0
     connection_timeout = 3.0
-    wait_time = constant_pacing(1.0)
+    wait_time = locust.wait_time.constant_pacing(1.0)

--- a/personas/route.py
+++ b/personas/route.py
@@ -1,8 +1,8 @@
 from personas import common
 
+import locust
 from locust import TaskSet, task
 from locust.contrib.fasthttp import FastHttpUser
-from locust.wait_time import constant_pacing
 
 
 class PersonaTaskSet(TaskSet):
@@ -25,4 +25,4 @@ class PersonaRoute(FastHttpUser):
     weight = 1
     network_timeout = 3.0
     connection_timeout = 3.0
-    wait_time = constant_pacing(1.0)
+    wait_time = locust.wait_time.constant_pacing(1.0)

--- a/personas/route_invalid.py
+++ b/personas/route_invalid.py
@@ -1,7 +1,7 @@
 import random
+import locust
 from locust import TaskSet, task
 from locust.contrib.fasthttp import FastHttpUser
-from locust.wait_time import constant_pacing
 
 from personas import common
 
@@ -24,6 +24,4 @@ class PersonaRouteInvalid(FastHttpUser):
     weight = 1
     network_timeout = 3.0
     connection_timeout = 3.0
-    wait_time = constant_pacing(1.0)
-    # min_wait = 500
-    # max_wait = 700
+    wait_time = locust.wait_time.constant_pacing(1.0)

--- a/personas/vrp.py
+++ b/personas/vrp.py
@@ -1,11 +1,11 @@
 import gevent
 import json
+import locust
 import random
 import os
 import time
 from locust import events, TaskSet, task
 from locust.contrib.fasthttp import FastHttpUser
-from locust.wait_time import constant_pacing
 
 from personas import common
 
@@ -73,7 +73,7 @@ class PersonaVRP(FastHttpUser):
     weight = 10
     network_timeout = 3.0
     connection_timeout = 3.0
-    wait_time = constant_pacing(1.0)
+    wait_time = locust.wait_time.constant_pacing(1.0)
 
 
 def get_random_vehicles_and_types(max_profiles):

--- a/run
+++ b/run
@@ -39,7 +39,7 @@ CURRENT_VERSION = "v1.0.0"
 
 def get_settings():
     # set arguments
-    args = docopt(__doc__, version=CURRENT_VERSION)
+    args = docopt(__doc__)
     settings = {}
     settings["base_url"] = (
         args["<base_url>"] if "http" in args["<base_url>"] else f"https://{args['<base_url>']}"
@@ -186,6 +186,9 @@ def print_info(settings):
 
 if __name__ == "__main__":
 
+    print("Load test for GraphHopper services.")
+    print(f"Version: {CURRENT_VERSION}.")
+    print("")
     settings = get_settings()
     print_info(settings)
     run_locust(settings)

--- a/run
+++ b/run
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""Load test GraphHopper
-
+"""
 Usage:
   run <base_url> [--persona=<persona>] [--duration=<length>] [--users=<cnt>] [--custom-output] [--debug] [--vrp-tomtom-probability <prob>] [--vrp-profiles <profiles>] [--points <points>] [--num-points <num_points>] [--vrp-max-profiles <vrp_max_profiles>] [--vrp-max-locations <vrp_max_locations>] [--master] [--expect-workers <clients_count>] [--worker] [--master-host <IP>] [--api-key <api_key>]
 
@@ -37,7 +36,7 @@ import time
 
 def get_settings():
     # set arguments
-    args = docopt(__doc__)
+    args = docopt(__doc__, version="v1.0.0")
     settings = {}
     settings["base_url"] = (
         args["<base_url>"] if "http" in args["<base_url>"] else f"https://{args['<base_url>']}"

--- a/run
+++ b/run
@@ -34,9 +34,12 @@ import sys
 import time
 
 
+CURRENT_VERSION = "v1.0.0"
+
+
 def get_settings():
     # set arguments
-    args = docopt(__doc__, version="v1.0.0")
+    args = docopt(__doc__, version=CURRENT_VERSION)
     settings = {}
     settings["base_url"] = (
         args["<base_url>"] if "http" in args["<base_url>"] else f"https://{args['<base_url>']}"


### PR DESCRIPTION
Closes #5.

This pull request shows the application tagline and version during run:

```
Load test for GraphHopper services.
Version: v1.0.0.
...
```

I [tried](https://gist.github.com/rokcarl/e82490602178568c01a575320a97c92f) doing it differently using [`docopt`](http://docopt.org/) features, but it didn't properly work. So this is the best alternative, i.e. the tagline and version will always be printed, even when running load tests. Otherwise, I'd have to go hacking into docopt.