### PR TITLE
Get rid of invokust

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,5 +1,18 @@
+import locust
+import os
+
+from utils import color
+
 from personas.isochrone import PersonaIsochrone
 from personas.matrix import PersonaMatrix
 from personas.route import PersonaRoute
 from personas.route_invalid import PersonaRouteInvalid
 from personas.vrp import PersonaVRP
+
+
+@locust.events.request_failure.add_listener
+def failure_handler(request_type, name, response_time, response_length, exception, **kw):
+    if "DEBUG" not in os.environ or os.environ["DEBUG"] != "yes":
+        return
+    msg = f"Request {name} ({request_type}) failed: {exception}"
+    print(color.red(msg), flush=True)

--- a/personas/common.py
+++ b/personas/common.py
@@ -3,8 +3,6 @@ import os
 import random
 import requests
 
-from locust import events
-
 
 def get_api_key_url_suffix(prefix):
     """Return something like `?key=1234567890` or empty if no key set"""
@@ -58,10 +56,3 @@ def get_points_query(task_set):
 
     num_points = 3 if "QUERY_POINTS_NUM" not in os.environ else int(os.environ["QUERY_POINTS_NUM"])
     return "&".join([f"point={lat},{lon}" for _ in range(num_points)])
-
-
-def setup_locust_debugging():
-    if "DEBUG" in os.environ and os.environ["DEBUG"] == "yes":
-        def report_error(request_type, name, response_time, exception, **kwargs):
-            print(f"Request {name} ({request_type}) failed: {exception}", flush=True)
-        events.request_failure.add_listener(report_error)

--- a/personas/isochrone.py
+++ b/personas/isochrone.py
@@ -9,7 +9,6 @@ class PersonaTaskSet(TaskSet):
     def on_start(self):
         self.client.verify = False
         self.api_key_url_suffix = common.get_api_key_url_suffix("&")
-        common.setup_locust_debugging()
 
     @task
     def get_isochrone(self):

--- a/personas/matrix.py
+++ b/personas/matrix.py
@@ -11,7 +11,6 @@ class PersonaTaskSet(TaskSet):
         self.client.verify = False
         self.api_key_url_suffix = common.get_api_key_url_suffix("&")
         self.points_query = common.get_points_query(self)
-        common.setup_locust_debugging()
 
     @task
     def get_matrix(self):

--- a/personas/route.py
+++ b/personas/route.py
@@ -11,7 +11,6 @@ class PersonaTaskSet(TaskSet):
         self.client.verify = False
         self.api_key_url_suffix = common.get_api_key_url_suffix("&")
         self.points_query = common.get_points_query(self)
-        common.setup_locust_debugging()
 
     @task
     def get_route(self):

--- a/personas/route_invalid.py
+++ b/personas/route_invalid.py
@@ -10,7 +10,6 @@ class PersonaTaskSet(TaskSet):
     def on_start(self):
         self.client.verify = False
         self.api_key_url_suffix = common.get_api_key_url_suffix("&")
-        common.setup_locust_debugging()
 
     @task
     def get_route(self):

--- a/personas/vrp.py
+++ b/personas/vrp.py
@@ -16,7 +16,6 @@ class PersonaTaskSet(TaskSet):
         self.max_profiles = int(os.environ["VRP_MAX_PROFILES"]) if "VRP_MAX_PROFILES" in os.environ else 1
         self.max_locations = int(os.environ["VRP_MAX_LOCATIONS"]) if "VRP_MAX_LOCATIONS" in os.environ else 10
         self.api_key_url_suffix = common.get_api_key_url_suffix("?")
-        common.setup_locust_debugging()
 
     @task
     def get_vrp(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 docopt==0.6.2
-invokust==1.0a0
-locust==1.1.1
+locust==1.4.1
 requests==2.23.0

--- a/run
+++ b/run
@@ -26,15 +26,15 @@ Options:
 """
 from docopt import docopt
 from utils import color
-import invokust
 import main
 import os
-import subprocess
+import run_as_cli
+import run_as_lib
 import sys
 import time
 
 
-CURRENT_VERSION = "v1.0.0"
+CURRENT_VERSION = "v1.1.0"
 
 
 def get_settings():
@@ -47,6 +47,7 @@ def get_settings():
     settings["users"] = args["--users"]
     settings["duration"] = args["--duration"]
     settings["custom-output"] = args["--custom-output"]
+    settings["debug"] = args["--debug"]
 
     # set persona
     persona_mapping = {
@@ -93,86 +94,9 @@ def get_settings():
 
 def run_locust(settings):
     if settings["custom-output"]:
-        run_locust_from_python(settings)
+        run_as_lib.run(settings)
     else:
-        run_locust_from_shell(settings)
-
-
-def run_locust_from_shell(settings):
-    cmd = (
-        f"locust --headless --host {settings['base_url']} "
-        f"-u {settings['users']} -r {settings['users']}"
-    )
-    if not settings["worker"]:
-        cmd += f" --run-time {settings['duration']}"
-    if settings["master"]:
-        cmd += f" --master --expect-workers={settings['expect-workers']}"
-    if settings["worker"]:
-        cmd += f" --worker --master-host={settings['master-host']}"
-    cmd += f" -f main.py {settings['persona_arg']}"
-    subprocess.run(cmd.split(" "))
-
-
-def run_locust_from_python(settings):
-    locust_settings = invokust.create_settings(
-        classes=[getattr(main, settings["persona_arg"])],
-        host=settings["base_url"],
-        num_users=settings["users"],
-        hatch_rate=settings["users"],
-        run_time=settings["duration"],
-    )
-
-    loadtest = invokust.LocustLoadTest(locust_settings)
-    loadtest.run()
-    stats = loadtest.stats()
-    print_results(stats)
-
-
-def print_results(data):
-    print("")
-    print(
-        f"{'Name':<30} {'# reqs':>7} {'# fails':>12} {'Avg':>7} {'Min':>7} {'Max':>7}  | {'Median':>7} {'req/s':>7}"
-    )
-    print("-" * 94)
-    for name, page in data["requests"].items():
-        for c in [
-            "min_response_time",
-            "max_response_time",
-            "avg_response_time",
-            "median_response_time",
-        ]:
-            page[c] = (
-                f"{float(page[c]):>7.0f}" if page[c] is not None else f"{'N/A':>7}"
-            )
-        nice_name = name.replace("_", " ")
-        num_fails = (
-            0 if name not in data["failures"] else data["failures"][name]["occurrences"]
-        )
-        print(
-            f"{nice_name:<30} {page['num_requests']:>7} {num_fails:>12} {page['avg_response_time']} {page['min_response_time']} {page['max_response_time']}  | {page['median_response_time']} {page['total_rps']:>7.2f}"
-        )
-    print("-" * 94)
-    pages = data["requests"].values()
-    total_num_requests = sum(page["num_requests"] for page in pages)
-    total_num_failures = sum(f["occurrences"] for f in data["failures"].values())
-    total_rps = sum(page["total_rps"] for page in pages)
-    print(
-        f"{'Total':<30} {total_num_requests:>7} {total_num_failures:>12} {' ':>34} {total_rps:>7.2f}"
-    )
-
-    # Errors
-    print("")
-    errors = sorted(data["failures"].values(), key=lambda x: -x["occurrences"])
-    if not errors:
-        print(color.green_bg("No errors!"))
-    else:
-        print(color.red_bg("Error report:"))
-        print("# occurrences  Error")
-        print("-" * 140)
-        for error in errors:
-            msg = f"{error['method']} {error['name']}: {error['error']}"
-            print(f"{error['occurrences']:>13}  {msg}")
-        print("-" * 140)
+        run_as_cli.run(settings)
 
 
 def print_info(settings):

--- a/run_as_cli.py
+++ b/run_as_cli.py
@@ -1,0 +1,21 @@
+"""
+Run Locust using system commands.
+"""
+
+
+import subprocess
+
+
+def run(settings):
+    cmd = (
+        f"locust --headless --host {settings['base_url']} "
+        f"-u {settings['users']} -r {settings['users']}"
+    )
+    if not settings["worker"]:
+        cmd += f" --run-time {settings['duration']}"
+    if settings["master"]:
+        cmd += f" --master --expect-workers={settings['expect-workers']}"
+    if settings["worker"]:
+        cmd += f" --worker --master-host={settings['master-host']}"
+    cmd += f" -f main.py {settings['persona_arg']}"
+    subprocess.run(cmd.split(" "))

--- a/run_as_lib.py
+++ b/run_as_lib.py
@@ -1,0 +1,138 @@
+"""
+Run Locust programmatically.
+"""
+
+import gevent
+
+import main
+from utils import color
+
+from locust.env import Environment
+from locust.stats import stats_history
+from locust.util.timespan import parse_timespan
+
+
+def run(settings):
+    """
+    Run the load test programmatically.
+    """
+    env = Environment(
+        user_classes=[getattr(main, settings["persona_arg"])],
+        host=settings["base_url"],
+    )
+    env.create_local_runner()
+
+    # start a greenlet that saves current stats to history
+    gevent.spawn(stats_history, env.runner)
+
+    # start the load test
+    env.runner.start(
+            user_count=int(settings["users"]),
+            spawn_rate=int(settings["users"]))
+
+    # add a listener for failures
+    env.events.request_failure.add_listener(main.failure_handler)
+
+    # stop the runner at the end
+    duration_s = parse_timespan(settings["duration"])
+    gevent.spawn_later(duration_s, lambda: stop(env))
+
+    # wait for the greenlets
+    env.runner.greenlet.join()
+
+
+def parse_locust_stats(env):
+    """
+    Turn the locust stats into more print-friendly data.
+    """
+    stats = env.runner.stats
+    statistics = {
+        "requests": {},
+        "failures": {},
+        "num_requests": stats.num_requests,
+        "num_requests_fail": stats.num_failures,
+    }
+
+    for name, value in stats.entries.items():
+        locust_task_name = "{0}_{1}".format(name[1], name[0])
+        statistics["requests"][locust_task_name] = {
+            "num_requests": value.num_requests,
+            "min_response_time": value.min_response_time,
+            "median_response_time": value.median_response_time,
+            "avg_response_time": value.avg_response_time,
+            "max_response_time": value.max_response_time,
+            "total_rps": value.total_rps,
+        }
+
+    for id, error in env.runner.errors.items():
+        error_dict = error.to_dict()
+        locust_task_name = "{0}_{1}".format(
+            error_dict["method"], error_dict["name"]
+        )
+        statistics["failures"][locust_task_name] = error_dict
+
+    return statistics
+
+
+def stop(env):
+    """
+    Stop the running load test.
+    """
+    env.runner.quit()
+    stats = parse_locust_stats(env)
+    print_results(stats)
+
+
+def print_results(data):
+    """
+    Print the end results of the load test.
+    """
+    print("")
+    print(
+        f"{'Name':<30} {'# reqs':>7} {'# fails':>12} {'Avg':>7} {'Min':>7} "
+        f"{'Max':>7}  | {'Median':>7} {'req/s':>7}"
+    )
+    print("-" * 94)
+    for name, page in data["requests"].items():
+        for c in [
+            "min_response_time",
+            "max_response_time",
+            "avg_response_time",
+            "median_response_time",
+        ]:
+            page[c] = (
+                f"{float(page[c]):>7.0f}" if page[c] is not None else f"{'N/A':>7}"
+            )
+        nice_name = name.replace("_", " ")
+        num_fails = (
+            0 if name not in data["failures"] else data["failures"][name]["occurrences"]
+        )
+        print(
+            f"{nice_name:<30} {page['num_requests']:>7} {num_fails:>12} "
+            f"{page['avg_response_time']} {page['min_response_time']} "
+            f"{page['max_response_time']}  | {page['median_response_time']} "
+            f"{page['total_rps']:>7.2f}"
+        )
+    print("-" * 94)
+    pages = data["requests"].values()
+    total_num_requests = sum(page["num_requests"] for page in pages)
+    total_num_failures = sum(f["occurrences"] for f in data["failures"].values())
+    total_rps = sum(page["total_rps"] for page in pages)
+    print(
+        f"{'Total':<30} {total_num_requests:>7} {total_num_failures:>12} "
+        f"{' ':>34} {total_rps:>7.2f}"
+    )
+
+    # Errors
+    print("")
+    errors = sorted(data["failures"].values(), key=lambda x: -x["occurrences"])
+    if not errors:
+        print(color.green_bg("No errors!"))
+    else:
+        print(color.red_bg("Error report:"))
+        print("# occurrences  Error")
+        print("-" * 140)
+        for error in errors:
+            msg = f"{error['method']} {error['name']}: {error['error']}"
+            print(f"{error['occurrences']:>13}  {msg}")
+        print("-" * 140)

--- a/utils/color.py
+++ b/utils/color.py
@@ -6,8 +6,18 @@ def red_bg(text):
     return _color("red_bg", text)
 
 
+def red(text):
+    return _color("red", text)
+
+
+def green(text):
+    return _color("green", text)
+
+
 def _color(color, text):
     mapping = {
+        "red": "0;31;40",
+        "green": "0;32;40",
         "green_bg": "6;30;42",
         "red_bg": "6;30;41",
     }


### PR DESCRIPTION
This PR fixes #12 where debugging and custom output doesn't work together by getting rid of Invokust, running Locust by using the Locust API when doing custom output and configuring the events for errors.

/cc @karussell 