### PR TITLE
VRP: change paths to no longer require /vrp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ push: build
 	docker push graphhopper/load-testing:latest
 
 shell:
-	docker run -it graphhopper/load-testing bash
+	docker run -it -v ${PWD}:/app graphhopper/load-testing bash
 
 python:
-	docker run -it graphhopper/load-testing python
+	docker run -it -v ${PWD}:/app graphhopper/load-testing python

--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ In its most basic form, all you need to do to start a load testing session, is t
   * If you're testing the matrix service at `/matrix` on HTTPS, then the base URL would be
     `https://example.com/`.
   * If you're testing the VRP service at `/api/1/vrp` on port 8080, then the base URL would be
-    `http://example.com:8080/api/1/vrp`. VRP is a bit special, in this regard, as the VRP
-    subpath of the URL might get cut off from the final URL, depending on implementation.
+    `http://example.com:8080/api/1`.
 * [optional] set the API key using `--api-key [key]`
 
 ### Three ways of running

--- a/personas/vrp.py
+++ b/personas/vrp.py
@@ -30,7 +30,7 @@ class PersonaTaskSet(TaskSet):
         payload = json.dumps(data)
 
         # optimize
-        url = f"/optimize{self.api_key_url_suffix}"
+        url = f"/vrp/optimize{self.api_key_url_suffix}"
         headers = {"content-type": "application/json"}
         with self.client.post(url, catch_response=True, data=payload, headers=headers, name="VRP complex Optimize", timeout=60) as response:
             if response.text is None:
@@ -49,7 +49,7 @@ class PersonaTaskSet(TaskSet):
             job_id = response.json()["job_id"]
 
         while True:
-            url = f"/solution/{job_id}{self.api_key_url_suffix}"
+            url = f"/vrp/solution/{job_id}{self.api_key_url_suffix}"
             with self.client.get(url, catch_response=True, name="VRP complex Solution", timeout=60) as response:
                 try:
                     response_data = response.json()


### PR DESCRIPTION
Fixes #19.

The change to require `/vrp` in the supplied base URL was done in [this commit](https://github.com/graphhopper/graphhopper-load-test/commit/451d7d53bbb4b74391e07344de6fa9d309b3adcf) and noted in [here in the readme](https://github.com/graphhopper/graphhopper-load-test/commit/451d7d53bbb4b74391e07344de6fa9d309b3adcf#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R49), saying:

> VRP is a bit special, in this regard, as the VRP subpath of the URL might get cut off from the final URL, depending on implementation.

I think this was a consequence of some architecture reasons that made sense at that time, but I don't see a reason we'd need it now.